### PR TITLE
feat: enable HSTS on gatsby cloud

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,6 +1,3 @@
-// custom typefaces
-import "typeface-montserrat"
-import "typeface-merriweather"
 // custom CSS styles
 import "./src/style.css"
 

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -9,6 +9,14 @@ module.exports = {
     siteUrl: `https://www.jameshush.com`,
   },
   plugins: [
+    {
+      resolve: `gatsby-plugin-gatsby-cloud`,
+      options: {
+        allPageHeaders: [
+          "Strict-Transport-Security: max-age=31536000; includeSubDomains; preload",
+        ],
+      },
+    },
     `gatsby-plugin-postcss`,
     `gatsby-plugin-image`,
     {

--- a/package.json
+++ b/package.json
@@ -37,8 +37,6 @@
     "react-helmet": "^6.1.0",
     "remark-github-plugin": "^1.4.0",
     "tailwindcss": "^3.0.7",
-    "typeface-merriweather": "0.0.72",
-    "typeface-montserrat": "0.0.75",
     "typescript": "^4.4.4"
   },
   "devDependencies": {


### PR DESCRIPTION
Enables [HSTS](https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Strict_Transport_Security_Cheat_Sheet.html) on gatsby cloud.