### PR TITLE
feat: lazy load iFrame in Chrome and instapage

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -368,6 +368,7 @@
             </div>
             <div class="embed-responsive embed-responsive-16by9 mt-4">
               <iframe
+                loading="lazy"
                 src="https://www.youtube.com/embed/dXHLdRCXU_g"
                 class="embed-responsive-item"
                 title="James Hush: The Punctual Engineer"

--- a/static/index.html
+++ b/static/index.html
@@ -879,5 +879,10 @@
 
       vgo("process")
     </script>
+    <script
+      src="//instant.page/5.1.0"
+      type="module"
+      integrity="sha384-by67kQnR+pyfy8yWP4kPO12fHKRLHZPfEsiSXR8u2IKcTdxD805MGUXBzVPnkLHw"
+    ></script>
   </body>
 </html>


### PR DESCRIPTION
Use trick from https://web.dev/iframe-lazy-loading/ to lazy load the iFrame in Chrome. Small band-aide. Full solution would be to move this page... One step at a time.

Also add instapage from Fershad's recommendation. Again small band-aide.